### PR TITLE
Augment activity pipe

### DIFF
--- a/src/lib/pipeline.js
+++ b/src/lib/pipeline.js
@@ -1,4 +1,5 @@
 import pipes from './pipes/index.js';
+import Utils from './utils.js';
 
 class PipeLine {
   constructor(rawData, pipeOutputCb) {

--- a/src/lib/pipes/activity-pipe.js
+++ b/src/lib/pipes/activity-pipe.js
@@ -1,0 +1,168 @@
+import Pipe from './pipe.js';
+import { cache } from '../utils.js';
+import fetch from 'node-fetch';
+import Settings from '../settings.js';
+
+
+class ActivityPipe extends Pipe {
+
+  run(){
+    return new Promise(async resolve => {
+
+      let activityList = cache.activities;
+      let augmentedActivities = [];
+
+      let pipe = this;
+      this.normalisedEvents.forEach(function(event){
+        let eventActivities = event.body.activity;
+        
+        // Enhance from what was in the activity field of the raw data
+        eventActivities.forEach(function(activity){
+          let activityId = pipe.normaliseActivityId(activity);
+
+          if (activityList[activityId] !== undefined){
+            augmentedActivities = augmentedActivities.concat(pipe.getActivityLabels(activityId));
+            // Get labels of broader activities too
+            augmentedActivities = augmentedActivities.concat(pipe.getBroaderActivities(activityId));
+          }else{
+            // It's from a publishers own list, just push as is
+            augmentedActivities.push(activity);
+          }
+        });
+
+        // Enhance from other fields
+        augmentedActivities = augmentedActivities.concat(pipe.extractActivities(event));
+
+        if (augmentedActivities.length > 0){
+          // Dedup activity labels
+          let uniqueAugmentedActivities = new Set(augmentedActivities);
+          uniqueAugmentedActivities = [...uniqueAugmentedActivities];
+          pipe.log(`Adding activities [${uniqueAugmentedActivities}]`);
+
+          // Finally, update the NormalisedEvent
+          event.body.activity = uniqueAugmentedActivities;
+        }
+
+      });
+
+      resolve(this.normalisedEvents);
+    });
+  }
+
+  /**
+  Most activities in the ActivityList only have a prefLabel but some have
+  altLabel so we should get this too. 
+  **/
+  getActivityLabels(activityKey){
+    let labels = [];
+    let activityList = cache.activities;
+      // Get the labels from the cached ActivityList
+      labels.push(activityList[activityKey]['prefLabel']);
+      if (activityList[activityKey]['altLabel'] !== undefined){
+        activityList[activityKey]['altLabel'].forEach(function(altLabel){
+          labels.push(altLabel);
+        });
+      }
+    return labels;
+  }
+
+  /**
+  Recursively checks activities in the ActivityList for broader field
+  and returns all labels of broader concepts. The broader field is an
+  array of ids that can also be found in the ActivityList.
+  **/
+  getBroaderActivities(activityKeys, activitiesSoFar = []){
+    let activityList = cache.activities;
+
+    if (!Array.isArray(activityKeys)){
+      activityKeys = [activityKeys];
+    }
+
+    let pipe = this;
+    activityKeys.forEach(function (activityKey){
+
+      let broaderKeys = activityList[activityKey]['broader'];
+      if (broaderKeys !== undefined){
+        let broaderLabels = [];
+        broaderKeys.forEach(function(broaderKey){
+          let broaderLabel = pipe.getActivityLabels(pipe.normaliseActivityId(broaderKey));
+          broaderLabels = broaderLabels.concat(broaderLabel);
+          pipe.log(`Found broader activity: [${broaderLabel}]`);
+        });
+        activitiesSoFar = activitiesSoFar.concat(broaderLabels);
+        return pipe.getBroaderActivities(broaderKeys, activitiesSoFar);
+      }
+
+    });
+
+    return activitiesSoFar;
+  }
+
+  /**
+  Check for labels from the ActivityList in the name and description
+  fields of the event, and apply these activities if found.
+  TODO: we could do a fuzzy match between the event description
+        and the activity definition and look at score to decide whether
+        to tag the event with that activity.
+  **/
+  extractActivities(normalisedEvent){
+    let activityList = cache.activities;
+    let labels = [];
+    let searchFields = ['name', 'description'];
+
+    let pipe = this;
+    // TODO: this is not efficient, maybe reindex by label in the cache?
+    for (const id of Object.keys(activityList)) {
+      let activity = activityList[id];
+      searchFields.forEach(function(field){
+        if (normalisedEvent.body[field] !== undefined){
+          if(pipe.searchTextForActivity(normalisedEvent.body[field].toLowerCase(), activity.prefLabel.toLowerCase())){
+            labels.push(activity.prefLabel);
+            labels = labels.concat(pipe.getBroaderActivities(id));
+          }
+          if (activity.altLabel !== undefined){
+            for (const i in activity.altLabel){
+              if(pipe.searchTextForActivity(normalisedEvent.body[field].toLowerCase(), activity.altLabel[i].toLowerCase())){
+                labels.push(activity.altLabel[i]);
+                labels = labels.concat(pipe.getBroaderActivities(id));
+              }
+
+            }
+          }
+        }
+      });
+
+    };
+
+    return labels;
+  }
+
+  /**
+  Simple string in string matching, but with a hack to only match
+  complete words, which helps to avoid false positives from substrings.
+  **/
+  searchTextForActivity(text, activity){
+    // Pad the activity name with spaces
+    activity = " "+activity+" ";
+    // Replace all non alpha chars with spaces
+    const nonAlpha = /^a-zA-Z\s/;
+    text = text.replace(nonAlpha, " ");
+    let result = text.search(activity) !== -1;
+    if (result){
+      this.log(`Found [${activity}] in "${text}"`);
+    }
+    return result;
+  }
+
+  /**
+  In the ActivityList ids take the form https://openactive.io/activity-list#{id}
+  but some data uses http, www, and/or a forward slash before the #{id}. So let's
+  strip these out.
+  **/
+  normaliseActivityId(activityId){
+    let normed = activityId.replace("http://", "https://").replace("www.", "").replace("/#", "#");
+    return normed;
+  }
+}
+
+export default ActivityPipe;

--- a/src/lib/pipes/activity-pipe.js
+++ b/src/lib/pipes/activity-pipe.js
@@ -138,16 +138,12 @@ class ActivityPipe extends Pipe {
   }
 
   /**
-  Simple string in string matching, but with a hack to only match
-  complete words, which helps to avoid false positives from substrings.
+  Simple string in string matching, only matches complete words,
+  which helps to avoid false positives from substrings.
   **/
   searchTextForActivity(text, activity){
-    // Pad the activity name with spaces
-    activity = " "+activity+" ";
-    // Replace all non alpha chars with spaces
-    const nonAlpha = /^a-zA-Z\s/;
-    text = text.replace(nonAlpha, " ");
-    let result = text.search(activity) !== -1;
+    const regex = new RegExp("\\b"+activity+"\\b");
+    let result = text.search(regex) !== -1;
     if (result){
       this.log(`Found [${activity}] in "${text}"`);
     }

--- a/src/lib/pipes/index.js
+++ b/src/lib/pipes/index.js
@@ -1,4 +1,5 @@
 import GeoPipe from './geo-pipe.js';
+import ActivityPipe from './activity-pipe.js';
 // import TestPipe from './test-pipe.js';
 import NormaliseEventPipe from './normalise-event-pipe.js';
 import NormaliseSlotPipe from './normalise-slot-pipe.js';
@@ -10,5 +11,6 @@ export default [
   NormaliseEventPipe,
   NormaliseSlotPipe,
   NormaliseScheduledSessionPipe,
+  ActivityPipe,
   GeoPipe
 ];

--- a/src/lib/pipes/pipe.js
+++ b/src/lib/pipes/pipe.js
@@ -22,22 +22,42 @@ class Pipe {
 
   parseActivity(activity){
     /**
-    This passes the whole activity object through for further processing 
-    by the activity augmentation pipe, making it into an array if it wasn't one.
+    This parses the activity field, which will be an object or an array of
+    objects, and gets the URI of each activity, passing back an array of strings.
+    These are further processed by the ActivityPipe.
     **/
-    /**
+    
+    let rawActivities = [];
     let activities = [];
-    if (activity ==  null){
-      // Because we should end up with *some* tags here after the activity augmentation pipe,
-      // so set it as an array in preparation
-      activities = [];
-    }else if (!Array.isArray(activity)){
-      activities = [activity];
+    if (!Array.isArray(activity)){
+      if (activity !== undefined && activity !== null){
+        rawActivities = [activity];
+      }
     }else{
-      activities = activity;
-    } **/
-    // Current mapping type is keyword, return something that matches
-    return "";
+      rawActivities = activity;
+    }
+    rawActivities.forEach(function(rawActivity){
+      // On the official Activity List
+      // Just use the id so we can get the names and other info from our cache.
+      if (rawActivity.inScheme == 'https://www.openactive.io/activity-list/activity-list.jsonld'){
+        if (rawActivity.id !== undefined){
+          activities.push(rawActivity.id);
+        }
+      }else{
+        // Publisher-owned ActivityList
+        // Not all of these have ids, and for the ones that do we probably
+        // don't want to go and fetch them to get their names, so let's just
+        // use the name in the object.
+        if (rawActivity.prefLabel !== undefined){
+          activities.push(rawActivity.prefLabel);
+        }
+        if (rawActivity.altLabel !== undefined){
+          activities.push(rawActivity.altLabel);
+        }
+      }
+    });
+
+    return activities;
   }
 
   parseLocation(location){


### PR DESCRIPTION
(Merge https://github.com/openactive/harvester/pull/25 first... I branched off that. The only commit to review for this PR is https://github.com/openactive/harvester/pull/26/commits/3634a66bb5db073ea41069ebc7dbe015927565d1)

Pipe to augment the `activity` field. In a NormalisedEvent, the value of activity field is an array of strings. The strings are the activity labels.

* If the activity values are not on the official ActivityList, it just keeps their labels as-is.
* If they are on the list, it gets `broader` activities from the ActivityList and adds those.
* It searches the `name` and `description` fields of the NormalisedEvent for all of the labels in the ActivityList, and tags with those as well if matched (full word match).

Stretch goals (not implemented): Cache the ActivityList in ElasticSearch, then do a *proper* comparison between the definitions in the ActivityList and the description fields, and use the match score to determine whether to tag or not.